### PR TITLE
ci: bump GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           release-type: python


### PR DESCRIPTION
Bump GitHub Actions to latest versions.

- `googleapis/release-please-action`: v4 -> v5

`build-and-push.yml` uses a reusable workflow (`chenwei791129/.github/...@main`) and has no action version to bump.